### PR TITLE
Resolve warning undefined array key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix: Resolve warning undefined array key ([#71](https://github.com/salcode/bootstrap4-genesis/issues/71))
 
 ## [1.3.2] - 2020-05-29
 - Update to Bootstrap v4.5.0

--- a/includes/css-classes.php
+++ b/includes/css-classes.php
@@ -71,6 +71,6 @@ function bs4g_genesis_attr_css_modifications( $attr, $context ) {
 			$css_mapping['content']           .= 'col-md-10';
 			break;
 	}
-	$attr['class'] .= ' ' . $css_mapping[ $context ] ?? '';
+	$attr['class'] .= ' ' . ( $css_mapping[ $context ] ?? '' );
 	return $attr;
 }


### PR DESCRIPTION
The problem was the string concatenation (.) was being applied before the null coalescing operator.

By adding paranthesis we ensure the null coalescing operator is applied when $css_mapping[ $context ] is null, which prevents this warning.

Warning: Undefined array key "entry-header" in
/bootstrap4-genesis/includes/css-classes.php on line 74

Warning: Undefined array key "entry-content" in
/bootstrap4-genesis/includes/css-classes.php on line 74

Resolves #71