### PR TITLE
Add HTML5 default $args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Fix: Resolve warning undefined array key ([#71](https://github.com/salcode/bootstrap4-genesis/issues/71))
+- Fix: `add_theme_support()` for `html5` was being called incorrectly ([#72](https://github.com/salcode/bootstrap4-genesis/issues/72))
 
 ## [1.3.2] - 2020-05-29
 - Update to Bootstrap v4.5.0

--- a/includes/theme-support.php
+++ b/includes/theme-support.php
@@ -8,7 +8,7 @@
 /**
  * 'html5': Use HTML5 markup.
  */
-add_theme_support( 'html5' );
+add_theme_support( 'html5', [ 'comment-list', 'comment-form', 'search-form' ] );
 
 
 /**


### PR DESCRIPTION
As of WordPress core 3.6.1 $args are required when adding "html5" theme support.

For backwards compatibility these args default to
'comment-list', 'comment-form', and 'search-form'

We are explicitly adding these default $args to prevent the notice we're seeing

Notice: Function add_theme_support( 'html5' ) was called incorrectly. You need to pass an array of types. Please see Debugging in WordPress for more information. (This message was added in version 3.6.1.) in /Users/sal/localwp/salferrarellotest/app/public/wp-includes/functions.php on line 6085

See https://github.com/WordPress/wordpress-develop/blob/3b1e57752d5dd737477873b6797e3f8209aec078/src/wp-includes/theme.php#L2619-L2620

Resolves #72